### PR TITLE
Add pixel, light sensor and led actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ API
 * Move
 
     ```
-    GET /3/<left-wheel-speed[-100:100]/<right-wheel-speed[-100:100]>/
+    GET /3/<left-wheel-speed[-100:100]>/<right-wheel-speed[-100:100]>/
     ```
 
     ie.,
@@ -78,9 +78,55 @@ API
     13
     ```
 
+* Pixel
+
+    ```
+    GET /6/<red>/<green>/<blue>
+    ```
+
+    Set the color of the onboard RGB led (pixel)
+
+    ie.,
+    ```
+    $curl --get http://192.168.4.1:1234/6/0/0/0/        // off
+    $curl --get http://192.168.4.1:1234/6/255/0/0/      // red
+    $curl --get http://192.168.4.1:1234/6/0/255/0/      // green
+    $curl --get http://192.168.4.1:1234/6/0/0/255/      // blue
+    $curl --get http://192.168.4.1:1234/6/255/255/255/  // white
+    ```
+
+* Sense Light
+
+    ```
+    GET /7/
+    ```
+
+    Returns a JSON formatted integer, for the light intensity level (0 - 1023).
+
+    ie.,
+    ```
+    $curl --get http://192.168.4.1:1234/7/
+    66
+    ```
+
+* Led
+
+    ```
+    GET /8/<state[0|1]>
+    ```
+
+    Turns the onboard led on or off.
+
+    ie.,
+    ```
+    curl --get http://192.168.4.1:1234/9/0/    // turns the onboard led off
+    curl --get http://192.168.4.1:1234/9/1/    // turns the onbboard led on
+    ```
+
 Authors
 ----------
 * Martin Abente Lahaye - tch@sugarlabs.org
+* Gary Servin - garyservin@gmail.com
 
 Cool Stuff
 -------------------

--- a/server/server.ino
+++ b/server/server.ino
@@ -235,7 +235,7 @@ void loop()
               move_servo_left.attach(SERVO_LEFT_PIN);
               servo_left_attached = true;
             }
-            int tmp = map(request_params.value1, 100, -100, 0, 180);
+            int tmp = map(request_params.value1, -100, 100, 0, 180);
             move_servo_left.write(constrain(tmp, 0, 180));
           }
 
@@ -247,7 +247,7 @@ void loop()
               move_servo_right.attach(SERVO_RIGHT_PIN);
               servo_right_attached = true;
             }
-            int tmp = map(request_params.value2, -100, 100, 0, 180);
+            int tmp = map(request_params.value2, 100, -100, 0, 180);
             move_servo_right.write(constrain(tmp, 0, 180));
           }
 


### PR DESCRIPTION
This adds support for the v1.1 hardware

Hardware specific
- Support for setting the color of the pixel (needs thel Adafruit_NeoPixel library to be installed)
- Support for reading the light sensor
- Changed values to control the servos for the new smaller servos

Other new actions (compatible with older hardware version)
- Turn the onboard led on or off
