### PR TITLE
Fix issue with new version of Arduino

### DIFF
--- a/server/server.ino
+++ b/server/server.ino
@@ -126,7 +126,7 @@ void setup()
   Serial.begin(SERVER_BAUD);
 }
 
-struct RequestParams server_get_params(char* line) {
+RequestParams server_get_params(char* line) {
   char taction[SERVER_BUFFER_SMALL];
   char tvalue1[SERVER_BUFFER_SMALL];
   char tvalue2[SERVER_BUFFER_SMALL];


### PR DESCRIPTION
With the latest arduino IDE 1.6.6 the code fails with some weird  about "structRequestParams" symbol undefined.
